### PR TITLE
updated main script filename in docker launch script

### DIFF
--- a/docker/stacoan.sh
+++ b/docker/stacoan.sh
@@ -7,7 +7,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-python /StaCoAn/src/main.py $@
+python /StaCoAn/src/stacoan.py $@
 # https://stackoverflow.com/questions/90418/exit-shell-script-based-on-process-exit-code
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 


### PR DESCRIPTION
Using docker script, I couldn't launch the container (error : not finding the main script file in /StaCoAn/src/main.py). I simply put the new main script filename in the stacoan.sh file inside the docker folder to make it work :)