### PR TITLE
Quick fix for undefined variable when running without a server

### DIFF
--- a/src/stacoan.py
+++ b/src/stacoan.py
@@ -149,6 +149,7 @@ def program(args):
 
     # Server(args) checks if the server should be run and handles the spawning of the server and control of it
     server(args)
+    server_enabled = config.getboolean("ProgramConfig", 'server_enabled')
 
     # For each project (read .ipa or .apk file), run the scripts.
     all_project_paths = args.project


### PR DESCRIPTION
Hi,

Just a quick fix due to the fact that a variable is not defined when running without a server.

Might make something cleaner later, it's just so that the program actually works. Is the fact that the check for whether the server should run is in the server() function intentional ? Otherwise, I might just take it out.