### PR TITLE
Reduce docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,26 +1,38 @@
-FROM python:3
+# -----------------------------------------------------------------------------------------
+# Start from Alpine OS with Oracle JDK8
+# -----------------------------------------------------------------------------------------
 
-RUN apt-get update && apt-get install upx software-properties-common -y
+FROM anapsix/alpine-java
 
-# https://github.com/re6exp/debian-jessie-oracle-jdk-8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list  && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list  && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886  && \
-    apt-get update
 
-RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections  && \
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections  && \
-    DEBIAN_FRONTEND=noninteractive  apt-get install -y --force-yes oracle-java8-installer oracle-java8-set-default
+# -----------------------------------------------------------------------------------------
+# Install Python3
+# -----------------------------------------------------------------------------------------
 
-RUN rm -rf /var/cache/oracle-jdk8-installer  && \
-    apt-get clean  && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache python3
+RUN python3 -m ensurepip
+RUN rm -r /usr/lib/python*/ensurepip
+RUN pip3 install --upgrade pip setuptools
+RUN if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi
+RUN if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi
+RUN rm -r /root/.cache
 
+
+# -----------------------------------------------------------------------------------------
+# Install StaCoAn
+# -----------------------------------------------------------------------------------------
+
+RUN apk add --no-cache git
 RUN git clone https://github.com/vincentcox/StaCoAn/
 WORKDIR /StaCoAn/src
 RUN pip3 install -r requirements.txt && chmod u+rwx /StaCoAn/src/jadx/bin/jadx
 
 COPY stacoan.sh /stacoan.sh
+
+
+# -----------------------------------------------------------------------------------------
+# Expose us
+# -----------------------------------------------------------------------------------------
 
 EXPOSE 8000
 EXPOSE 8080


### PR DESCRIPTION
This reduces the image size from 1.44GB to 264MB. This is a decrease of more than 80%. 
We achieve this by using Alpine Linux with JDK 8 as our base image.